### PR TITLE
BUG: Remove fixed batch size in training method

### DIFF
--- a/src/icon_registration/train.py
+++ b/src/icon_registration/train.py
@@ -2,7 +2,7 @@ import torch
 
 
 def train2d(net, optimizer, d1, d2, epochs=400):
-
+    batch_size = net.identityMap.shape[0]
     loss_history = []
     print("[", end="")
     for epoch in range(epochs):
@@ -10,7 +10,7 @@ def train2d(net, optimizer, d1, d2, epochs=400):
         if (epoch + 1) % 50 == 0:
             print("]", end="\n[")
         for A, B in list(zip(d1, d2)):
-            if A[0].size()[0] == 128:
+            if A[0].size()[0] == batch_size:
                 image_A = A[0].cuda()
                 image_B = B[0].cuda()
                 optimizer.zero_grad()


### PR DESCRIPTION
Suggesting a change to fix an attribute error observed when running `2d_training_example.py` on a batch size other than the default 128.

`2d_training_example.py` contains a check to skip a training batch if its size is not 128 (hardcoded). In the case where the user sets a different batch size, training is skipped for all batches and `net.forward` is never called. The `phi_AB_vectorfield` attribute is only initialized in the [InverseConsistentNet.forward](https://github.com/uncbiag/ICON/blob/master/src/icon_registration/inverseConsistentNet.py#L24) method, so attempting to access `net.phi_AB_vectorfield` fails.

Suggested change removes this check entirely so that training may run on any batch size.

---
Full error:

```
[-Traceback (most recent call last):
  File "training_scripts\2d_triangles_example.py", line 55, in <module>
    y = np.array(train.train2d(net, optimizer, d1, d2, epochs=50))
  File "C:\Users\tom.birdsong\Anaconda3\envs\venv-itk\lib\site-packages\icon_registration\train.py", line 29, in train2d
    net.phi_AB_vectorfield[:, :, 1:, :-1]
  File "C:\Users\tom.birdsong\Anaconda3\envs\venv-itk\lib\site-packages\torch\nn\modules\module.py", line 1130, in __getattr__
    raise AttributeError("'{}' object has no attribute '{}'".format(
AttributeError: 'InverseConsistentNet' object has no attribute 'phi_AB_vectorfield'
```