### PR TITLE
ENH: Fix warped output image alignment for training visualization

### DIFF
--- a/src/icon_registration/visualize.py
+++ b/src/icon_registration/visualize.py
@@ -42,8 +42,10 @@ def visualizeRegistration(net, image_A, image_B, N, path):
     ax.axes.xaxis.set_ticks([])
     ax.axes.yaxis.set_ticks([])
     plt.title("Image B Warped")
-    plt.imshow(net.warped_image_B.detach().cpu()[N, 0])
-    show_as_grid(net.phi_AB_vectorfield[N])
+    phi_vectorfield_n = net.phi_AB_vectorfield[N]
+    extent = [-0.5,phi_vectorfield_n.size()[-2] - 0.5,phi_vectorfield_n.size()[-1] - 0.5,-0.5]
+    plt.imshow(net.warped_image_B.detach().cpu()[N, 0],extent=extent,aspect='auto')
+    show_as_grid(phi_vectorfield_n)
     plt.subplot(3, 2, 3)
     ax = plt.gca()
     ax.axes.xaxis.set_ticks([])
@@ -88,5 +90,7 @@ def visualizeRegistrationCompact(net, image_A, image_B, N):
     ax.axes.xaxis.set_ticks([])
     ax.axes.yaxis.set_ticks([])
     # plt.title("Image B Warped")
-    plt.imshow(net.warped_image_B.detach().cpu()[N, 0])
-    show_as_grid(net.phi_AB_vectorfield[N])
+    phi_vectorfield_n = net.phi_AB_vectorfield[N]
+    extent = [-0.5,phi_vectorfield_n.size()[-2] - 0.5,phi_vectorfield_n.size()[-1] - 0.5,-0.5]
+    plt.imshow(net.warped_image_B.detach().cpu()[N, 0],extent=extent,aspect='auto')
+    show_as_grid(phi_vectorfield_n)


### PR DESCRIPTION
Add image extent to `imshow` in intermediate + final field visualization to better fit training data dimensions.

---

Original:

Custom data
![0](https://user-images.githubusercontent.com/40648863/138317498-eb4d3849-0dc2-41a7-b308-0da338ed32ec.png)



Triangle training data
![8](https://user-images.githubusercontent.com/40648863/138318123-85245a4b-d414-45b5-9620-f75bc139bcd9.png)


---

Updated:

Custom data (field fits image extent)
![0](https://user-images.githubusercontent.com/40648863/138317631-4382a5c8-6da4-4624-8eeb-ce73b173367b.png)

Triangle training data (no effective change)
![0](https://user-images.githubusercontent.com/40648863/138317840-98056fb9-8050-4033-aa34-10e84a635528.png)

