### PR TITLE
Add multichanel support

### DIFF
--- a/src/icon_registration/__init__.py
+++ b/src/icon_registration/__init__.py
@@ -5,6 +5,8 @@ from icon_registration.losses import (
     GradientICON,
     InverseConsistentNet,
     gaussian_blur,
+    ssd_only_interpolated,
+    ssd,
     SSDOnlyInterpolated,
     SSD,
     NCC

--- a/src/icon_registration/__init__.py
+++ b/src/icon_registration/__init__.py
@@ -5,8 +5,9 @@ from icon_registration.losses import (
     GradientICON,
     InverseConsistentNet,
     gaussian_blur,
-    ssd_only_interpolated,
-    ssd,
+    SSDOnlyInterpolated,
+    SSD,
+    NCC
 )
 from icon_registration.network_wrappers import (
     DownsampleRegistration,

--- a/src/icon_registration/itk_wrapper.py
+++ b/src/icon_registration/itk_wrapper.py
@@ -79,6 +79,69 @@ def register_pair(
     else:
         return itk_transforms + (to_floats(loss),)
 
+def register_pair_with_multimodalities(
+    model, image_A: list, image_B: list, finetune_steps=None, return_artifacts=False
+) -> "(itk.CompositeTransform, itk.CompositeTransform)":
+
+    assert len(image_A) == len(image_B), "image_A and image_B should have the same number of modalities."
+
+    # send model to cpu or gpu depending on config- auto detects capability
+    model.to(config.device)
+
+    A_npy, B_npy = [], []
+    for image_a, image_b in zip(image_A, image_B):
+        assert isinstance(image_a, itk.Image)
+        assert isinstance(image_b, itk.Image)
+
+        A_npy.append(np.array(image_a))
+        B_npy.append(np.array(image_b))
+
+        assert(np.max(A_npy[-1]) != np.min(A_npy[-1]))
+        assert(np.max(B_npy[-1]) != np.min(B_npy[-1]))
+
+    # turn images into torch Tensors: add batch dimensions (each of length 1)
+    A_trch = torch.Tensor(np.array(A_npy)).to(config.device)[None]
+    B_trch = torch.Tensor(np.array(B_npy)).to(config.device)[None]
+
+    shape = model.identity_map.shape[2:]
+    if list(A_trch.shape[2:]) != list(shape) or (list(B_trch.shape[2:]) != list(shape)):
+        # Here we resize the input images to the shape expected by the neural network. This affects the
+        # pixel stride as well as the magnitude of the displacement vectors of the resulting
+        # displacement field, which create_itk_transform will have to compensate for.
+        A_trch = F.interpolate(
+            A_trch, size=shape, mode="trilinear", align_corners=False
+        )
+        B_trch = F.interpolate(
+            B_trch, size=shape, mode="trilinear", align_corners=False
+        )
+
+    if finetune_steps == 0:
+        raise Exception("To indicate no finetune_steps, pass finetune_steps=None")
+
+    if finetune_steps == None:
+        with torch.no_grad():
+            loss = model(A_trch, B_trch)
+    else:
+        loss = finetune_execute(model, A_trch, B_trch, finetune_steps)
+
+    # phi_AB and phi_BA are [1, 3, H, W, D] pytorch tensors representing the forward and backward
+    # maps computed by the model
+    if hasattr(model, "prepare_for_viz"):
+        with torch.no_grad():
+            model.prepare_for_viz(A_trch, B_trch)
+    phi_AB = model.phi_AB(model.identity_map)
+    phi_BA = model.phi_BA(model.identity_map)
+
+    # the parameters ident, image_A, and image_B are used for their metadata
+    itk_transforms = (
+        create_itk_transform(phi_AB, model.identity_map, image_A[0], image_B[0]),
+        create_itk_transform(phi_BA, model.identity_map, image_B[0], image_A[0]),
+    )
+    if not return_artifacts:
+        return itk_transforms
+    else:
+        return itk_transforms + (to_floats(loss),)
+
 
 def create_itk_transform(phi, ident, image_A, image_B) -> "itk.CompositeTransform":
 

--- a/src/icon_registration/losses.py
+++ b/src/icon_registration/losses.py
@@ -32,6 +32,8 @@ class InverseConsistentNet(network_wrappers.RegistrationModule):
 
         self.regis_net = network
         self.lmbda = lmbda
+
+        assert isinstance(similarity, SimilarityBase)
         self.similarity = similarity
 
     def __call__(self, image_A, image_B) -> ICONLoss:
@@ -52,26 +54,28 @@ class InverseConsistentNet(network_wrappers.RegistrationModule):
         self.phi_AB_vectorfield = self.phi_AB(self.identity_map)
         self.phi_BA_vectorfield = self.phi_BA(self.identity_map)
 
-        # tag images during warping so that the similarity measure
-        # can use information about whether a sample is interpolated
-        # or extrapolated
-
-        inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
-        if len(self.input_shape) - 2 == 3:
-            inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
-        elif len(self.input_shape) - 2 == 2:
-            inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+        if self.similarity.isInterpolated:
+            # tag images during warping so that the similarity measure
+            # can use information about whether a sample is interpolated
+            # or extrapolated
+            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            if len(self.input_shape) - 2 == 3:
+                inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
+            elif len(self.input_shape) - 2 == 2:
+                inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+            else:
+                inbounds_tag[:, :, 1:-1] = 1.0
         else:
-            inbounds_tag[:, :, 1:-1] = 1.0
+            inbounds_tag = None
 
         self.warped_image_A = compute_warped_image_multiNC(
-            torch.cat([image_A, inbounds_tag], axis=1),
+            torch.cat([image_A, inbounds_tag], axis=1) if inbounds_tag else image_A,
             self.phi_AB_vectorfield,
             self.spacing,
             1,
         )
         self.warped_image_B = compute_warped_image_multiNC(
-            torch.cat([image_B, inbounds_tag], axis=1),
+            torch.cat([image_B, inbounds_tag], axis=1) if inbounds_tag else image_B,
             self.phi_BA_vectorfield,
             self.spacing,
             1,
@@ -176,23 +180,25 @@ class GradientICON(network_wrappers.RegistrationModule):
         self.phi_AB_vectorfield = phi_AB(self.identity_map)
         self.phi_BA_vectorfield = phi_BA(self.identity_map)
 
-        # tag images during warping so that the similarity measure
-        # can use information about whether a sample is interpolated
-        # or extrapolated
-
-        inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
-        if len(self.input_shape) - 2 == 3:
-            inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
-        elif len(self.input_shape) - 2 == 2:
-            inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+        if self.similarity.isInterpolated:
+            # tag images during warping so that the similarity measure
+            # can use information about whether a sample is interpolated
+            # or extrapolated
+            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            if len(self.input_shape) - 2 == 3:
+                inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
+            elif len(self.input_shape) - 2 == 2:
+                inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+            else:
+                inbounds_tag[:, :, 1:-1] = 1.0
         else:
-            inbounds_tag[:, :, 1:-1] = 1.0
+            inbounds_tag = None
 
         self.warped_image_A = self.as_function(
-            torch.cat([image_A, inbounds_tag], axis=1)
+            torch.cat([image_A, inbounds_tag], axis=1) if inbounds_tag else image_A
         )(self.phi_AB_vectorfield)
         self.warped_image_B = self.as_function(
-            torch.cat([image_B, inbounds_tag], axis=1)
+            torch.cat([image_B, inbounds_tag], axis=1) if inbounds_tag else image_B
         )(self.phi_BA_vectorfield)
         similarity_loss = self.similarity(
             self.warped_image_A, image_B
@@ -301,20 +307,22 @@ class BendingEnergyNet(network_wrappers.RegistrationModule):
 
     def compute_similarity_measure(self, phi_AB_vectorfield, image_A, image_B):
 
-        # tag images during warping so that the similarity measure
-        # can use information about whether a sample is interpolated
-        # or extrapolated
-
-        inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
-        if len(self.input_shape) - 2 == 3:
-            inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
-        elif len(self.input_shape) - 2 == 2:
-            inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+        if self.similarity.isInterpolated:
+            # tag images during warping so that the similarity measure
+            # can use information about whether a sample is interpolated
+            # or extrapolated
+            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            if len(self.input_shape) - 2 == 3:
+                inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
+            elif len(self.input_shape) - 2 == 2:
+                inbounds_tag[:, :, 1:-1, 1:-1] = 1.0
+            else:
+                inbounds_tag[:, :, 1:-1] = 1.0
         else:
-            inbounds_tag[:, :, 1:-1] = 1.0
+            inbounds_tag = None
 
         self.warped_image_A = self.as_function(
-            torch.cat([image_A, inbounds_tag], axis=1)
+            torch.cat([image_A, inbounds_tag], axis=1) if inbounds_tag else image_A
         )(phi_AB_vectorfield)
         
         similarity_loss = self.similarity(
@@ -407,11 +415,19 @@ def normalize(image):
     return image_centered / stddev
 
 
-def ncc(image_A, image_B):
-    A = normalize(image_A[:, :1])
-    B = normalize(image_B)
-    res = torch.mean(A * B)
-    return 1 - res
+class SimilarityBase:
+    def __init__(self, isInterpolated=False):
+        self.isInterpolated = isInterpolated
+
+class NCC(SimilarityBase):
+    def __init__(self):
+        super().__init__(isInterpolated=False)
+
+    def __call__(self, image_A, image_B):
+        A = normalize(image_A)
+        B = normalize(image_B)
+        res = torch.mean(A * B)
+        return 1 - res
 
 
 def gaussian_blur(tensor, kernel_size, sigma, padding="same"):
@@ -419,30 +435,32 @@ def gaussian_blur(tensor, kernel_size, sigma, padding="same"):
         tensor.device, dtype=tensor.dtype
     )
     out = tensor
+    group = tensor.shape[1]
 
     if len(tensor.shape) - 2 == 1:
-        out = torch.conv1d(out, kernel1d[None, None, :], padding="same")
+        out = torch.conv1d(out, kernel1d[None, None, :].expand(group,-1,-1), padding="same", groups=group)
     elif len(tensor.shape) - 2 == 2:
-        out = torch.conv2d(out, kernel1d[None, None, :, None], padding="same")
-        out = torch.conv2d(out, kernel1d[None, None, None, :], padding="same")
+        out = torch.conv2d(out, kernel1d[None, None, :, None].expand(group,-1,-1,-1), padding="same", groups=group)
+        out = torch.conv2d(out, kernel1d[None, None, None, :].expand(group,-1,-1,-1), padding="same", groups=group)
     elif len(tensor.shape) - 2 == 3:
-        out = torch.conv3d(out, kernel1d[None, None, :, None, None], padding="same")
-        out = torch.conv3d(out, kernel1d[None, None, None, :, None], padding="same")
-        out = torch.conv3d(out, kernel1d[None, None, None, None, :], padding="same")
+        out = torch.conv3d(out, kernel1d[None, None, :, None, None].expand(group,-1,-1,-1,-1), padding="same", groups=group)
+        out = torch.conv3d(out, kernel1d[None, None, None, :, None].expand(group,-1,-1,-1,-1), padding="same", groups=group)
+        out = torch.conv3d(out, kernel1d[None, None, None, None, :].expand(group,-1,-1,-1,-1), padding="same", groups=group)
 
     return out
 
 
-class LNCC:
+class LNCC(SimilarityBase):
     def __init__(self, sigma):
+        super().__init__(isInterpolated=False)
         self.sigma = sigma
 
     def blur(self, tensor):
         return gaussian_blur(tensor, self.sigma * 4 + 1, self.sigma)
 
     def __call__(self, image_A, image_B):
-        I = image_A[:, :1]
-        J = image_B[:, :1]
+        I = image_A
+        J = image_B
         return torch.mean(
             1
             - (self.blur(I * J) - (self.blur(I) * self.blur(J)))
@@ -453,8 +471,9 @@ class LNCC:
         )
 
 
-class LNCCOnlyInterpolated:
+class LNCCOnlyInterpolated(SimilarityBase):
     def __init__(self, sigma):
+        super().__init__(isInterpolated=True)
         self.sigma = sigma
 
     def blur(self, tensor):
@@ -462,8 +481,8 @@ class LNCCOnlyInterpolated:
 
     def __call__(self, image_A, image_B):
 
-        I = image_A[:, :1]
-        J = image_B[:, :1]
+        I = image_A[:, :-1]
+        J = image_B
         lncc_everywhere = 1 - (
             self.blur(I * J) - (self.blur(I) * self.blur(J))
         ) / torch.sqrt(
@@ -472,7 +491,7 @@ class LNCCOnlyInterpolated:
         )
 
         with torch.no_grad():
-            A_inbounds = image_A[:, 1:]
+            A_inbounds = image_A[:, -1:]
 
             inbounds_mask = self.blur(A_inbounds) > 0.999
 
@@ -490,19 +509,21 @@ class LNCCOnlyInterpolated:
         return torch.mean(lncc_loss)
 
 
-class BlurredSSD:
+class BlurredSSD(SimilarityBase):
     def __init__(self, sigma):
+        super().__init__(isInterpolated=False)
         self.sigma = sigma
 
     def blur(self, tensor):
         return gaussian_blur(tensor, self.sigma * 4 + 1, self.sigma)
 
     def __call__(self, image_A, image_B):
-        return torch.mean((self.blur(image_A[:, :1]) - self.blur(image_B[:, :1])) ** 2)
+        return torch.mean((self.blur(image_A) - self.blur(image_B)) ** 2)
 
 
-class AdaptiveNCC:
+class AdaptiveNCC(SimilarityBase):
     def __init__(self, level=4, threshold=0.1, gamma=1.5, sigma=2):
+        super().__init__(isInterpolated=False)
         self.level = level
         self.threshold = threshold
         self.gamma = gamma
@@ -513,7 +534,7 @@ class AdaptiveNCC:
 
     def __call__(self, image_A, image_B):
         def _nccBeforeMean(image_A, image_B):
-            A = normalize(image_A[:, :1])
+            A = normalize(image_A)
             B = normalize(image_B)
             res = torch.mean(A * B, dim=(1, 2, 3, 4))
             return 1 - res
@@ -543,25 +564,32 @@ class AdaptiveNCC:
 
         return torch.mean(sim_loss)
 
+class SSD(SimilarityBase):
+    def __init__(self):
+        super().__init__(isInterpolated=False)
 
-def ssd(image_A, image_B):
-    return torch.mean((image_A[:, :1] - image_B[:, :1]) ** 2)
+    def __call__(self, image_A, image_B):
+        return torch.mean((image_A - image_B) ** 2)
 
+class SSDOnlyInterpolated(SimilarityBase):
+    def __init__(self):
+        super().__init__(isInterpolated=True)
 
-def ssd_only_interpolated(image_A, image_B):
-    if len(image_A.shape) - 2 == 3:
-        dimensions_to_sum_over = [2, 3, 4]
-    elif len(image_A.shape) - 2 == 2:
-        dimensions_to_sum_over = [2, 3]
-    elif len(image_A.shape) - 2 == 1:
-        dimensions_to_sum_over = [2]
-    inbounds_mask = image_A[:, 1:]
-    image_A = image_A[:, :1]
-    inbounds_squared_distance = inbounds_mask * (image_A - image_B) ** 2
-    sum_squared_distance = torch.sum(inbounds_squared_distance, dimensions_to_sum_over)
-    divisor = torch.sum(inbounds_mask, dimensions_to_sum_over)
-    ssds = sum_squared_distance / divisor
-    return torch.mean(ssds)
+    def __call__(self, image_A, image_B):
+        if len(image_A.shape) - 2 == 3:
+            dimensions_to_sum_over = [2, 3, 4]
+        elif len(image_A.shape) - 2 == 2:
+            dimensions_to_sum_over = [2, 3]
+        elif len(image_A.shape) - 2 == 1:
+            dimensions_to_sum_over = [2]
+
+        inbounds_mask = image_A[:, -1:]
+        image_A = image_A[:, :-1]
+        inbounds_squared_distance = inbounds_mask * (image_A - image_B) ** 2
+        sum_squared_distance = torch.sum(inbounds_squared_distance, dimensions_to_sum_over)
+        divisor = torch.sum(inbounds_mask, dimensions_to_sum_over)
+        ssds = sum_squared_distance / divisor
+        return torch.mean(ssds)
 
 
 def flips(phi, in_percentage=False):

--- a/src/icon_registration/losses.py
+++ b/src/icon_registration/losses.py
@@ -58,7 +58,7 @@ class InverseConsistentNet(network_wrappers.RegistrationModule):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated
-            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            inbounds_tag = torch.zeros([image_A.shape[0]] + [1] + list(image_A.shape[2:]), device=image_A.device)
             if len(self.input_shape) - 2 == 3:
                 inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
             elif len(self.input_shape) - 2 == 2:
@@ -184,7 +184,7 @@ class GradientICON(network_wrappers.RegistrationModule):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated
-            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            inbounds_tag = torch.zeros([image_A.shape[0]] + [1] + list(image_A.shape[2:]), device=image_A.device)
             if len(self.input_shape) - 2 == 3:
                 inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
             elif len(self.input_shape) - 2 == 2:
@@ -311,7 +311,7 @@ class BendingEnergyNet(network_wrappers.RegistrationModule):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated
-            inbounds_tag = torch.zeros(tuple(image_A.shape), device=image_A.device)
+            inbounds_tag = torch.zeros([image_A.shape[0]] + [1] + list(image_A.shape[2:]), device=image_A.device)
             if len(self.input_shape) - 2 == 3:
                 inbounds_tag[:, :, 1:-1, 1:-1, 1:-1] = 1.0
             elif len(self.input_shape) - 2 == 2:
@@ -594,7 +594,7 @@ class SSDOnlyInterpolated(SimilarityBase):
         inbounds_mask = image_A[:, -1:]
         image_A = image_A[:, :-1]
         assert image_A.shape == image_B.shape, "The shape of image_A and image_B sould be the same."
-        
+
         inbounds_squared_distance = inbounds_mask * (image_A - image_B) ** 2
         sum_squared_distance = torch.sum(inbounds_squared_distance, dimensions_to_sum_over)
         divisor = torch.sum(inbounds_mask, dimensions_to_sum_over)

--- a/src/icon_registration/losses.py
+++ b/src/icon_registration/losses.py
@@ -54,7 +54,7 @@ class InverseConsistentNet(network_wrappers.RegistrationModule):
         self.phi_AB_vectorfield = self.phi_AB(self.identity_map)
         self.phi_BA_vectorfield = self.phi_BA(self.identity_map)
 
-        if self.similarity.isInterpolated:
+        if getattr(self.similarity, "isInterpolated", False):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated
@@ -180,7 +180,7 @@ class GradientICON(network_wrappers.RegistrationModule):
         self.phi_AB_vectorfield = phi_AB(self.identity_map)
         self.phi_BA_vectorfield = phi_BA(self.identity_map)
 
-        if self.similarity.isInterpolated:
+        if getattr(self.similarity, "isInterpolated", False):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated
@@ -307,7 +307,7 @@ class BendingEnergyNet(network_wrappers.RegistrationModule):
 
     def compute_similarity_measure(self, phi_AB_vectorfield, image_A, image_B):
 
-        if self.similarity.isInterpolated:
+        if getattr(self.similarity, "isInterpolated", False):
             # tag images during warping so that the similarity measure
             # can use information about whether a sample is interpolated
             # or extrapolated

--- a/src/icon_registration/losses.py
+++ b/src/icon_registration/losses.py
@@ -629,3 +629,8 @@ def flips(phi, in_percentage=False):
             return torch.sum(du < 0) / phi.shape[0]
     else:
         raise ValueError()
+
+
+######## These are kept for backward-capability. #########
+ssd = SSD()
+ssd_only_interpolated = SSDOnlyInterpolated()

--- a/src/icon_registration/networks.py
+++ b/src/icon_registration/networks.py
@@ -196,7 +196,7 @@ def pad_or_crop(x, shape, dimension):
 
 
 class UNet2(nn.Module):
-    def __init__(self, num_layers, channels, dimension, input_channels=2):
+    def __init__(self, num_layers, channels, dimension):
         super().__init__()
         self.dimension = dimension
         if dimension == 2:
@@ -247,7 +247,7 @@ class UNet2(nn.Module):
         #                Residual(up_channels_out[depth])
         #            )
         self.lastConv = self.Conv(
-            input_channels + up_channels_out[0], dimension, kernel_size=3, padding=1
+            down_channels[0] + up_channels_out[0], dimension, kernel_size=3, padding=1
         )
         torch.nn.init.zeros_(self.lastConv.weight)
         torch.nn.init.zeros_(self.lastConv.bias)
@@ -531,7 +531,6 @@ def tallUNet2(dimension=2, input_channels=1):
         5,
         [[input_channels*2, 16, 32, 64, 256, 512], [16, 32, 64, 128, 256]],
         dimension,
-        input_channels=input_channels*2,
     )
 
 

--- a/src/icon_registration/networks.py
+++ b/src/icon_registration/networks.py
@@ -526,12 +526,12 @@ def tallerUNet2(dimension=2):
     )
 
 
-def tallUNet2(dimension=2, input_channels=2):
+def tallUNet2(dimension=2, input_channels=1):
     return UNet2(
         5,
-        [[2, 16, 32, 64, 256, 512], [16, 32, 64, 128, 256]],
+        [[input_channels*2, 16, 32, 64, 256, 512], [16, 32, 64, 128, 256]],
         dimension,
-        input_channels=input_channels,
+        input_channels=input_channels*2,
     )
 
 

--- a/src/icon_registration/pretrained_models/OAI_knees.py
+++ b/src/icon_registration/pretrained_models/OAI_knees.py
@@ -7,6 +7,7 @@ from icon_registration import config
 
 from .. import networks
 from .lung_ct import init_network
+from ..losses import SSD
 
 
 def OAI_knees_registration_model(pretrained=True):
@@ -29,7 +30,7 @@ def OAI_knees_registration_model(pretrained=True):
             hires_net,
             icon_registration.FunctionFromVectorField(networks.tallUNet2(dimension=3)),
         ),
-        lambda x, y: torch.mean((x - y) ** 2),
+        SSD(),
         3600,
     )
 

--- a/test/test_2d_registration_train.py
+++ b/test/test_2d_registration_train.py
@@ -61,6 +61,7 @@ class Test2DRegistrationTrain(unittest.TestCase):
 
         import icon_registration.data as data
         import icon_registration.networks as networks
+        from icon_registration import SSD
 
         import numpy as np
         import torch
@@ -88,7 +89,7 @@ class Test2DRegistrationTrain(unittest.TestCase):
             icon_registration.FunctionFromVectorField(networks.tallUNet2(dimension=2)),
             # Our image similarity metric. The last channel of x and y is whether the value is interpolated or extrapolated,
             # which is used by some metrics but not this one
-            lambda x, y: torch.mean((x[:, :1] - y[:, :1]) ** 2),
+            SSD(),
             lmbda,
         )
 

--- a/test/test_2d_registration_train.py
+++ b/test/test_2d_registration_train.py
@@ -7,6 +7,7 @@ class Test2DRegistrationTrain(unittest.TestCase):
 
         import icon_registration.data as data
         import icon_registration.networks as networks
+        from icon_registration import SSD
 
         import numpy as np
         import torch
@@ -34,7 +35,7 @@ class Test2DRegistrationTrain(unittest.TestCase):
             icon_registration.FunctionFromVectorField(networks.tallUNet2(dimension=2)),
             # Our image similarity metric. The last channel of x and y is whether the value is interpolated or extrapolated,
             # which is used by some metrics but not this one
-            lambda x, y: torch.mean((x[:, :1] - y[:, :1]) ** 2),
+            SSD(),
             lmbda,
         )
 


### PR DESCRIPTION
Support multichannel image as input to the network and similarity measure.

It is useful when there are multiple modalities such as MRI-T1, MRI-T2 and MRI-TI enhanced images. 

This pull request contains the three following major changes:
1. Expose an argument called input_channels for tallUNet2 function. This argument indicates the number of channels of one input image tensor.
2. Refactor all the similarity measures to inherit from SimilarityBase class. And SimilarityBase class contains a variable member indicating whether this Similarity Measure requires inbounds_tag for evaluation.
3. Add itk interface for multi-modality registration.