### PR TITLE
remove unneeded check

### DIFF
--- a/src/icon_registration/losses.py
+++ b/src/icon_registration/losses.py
@@ -32,8 +32,6 @@ class InverseConsistentNet(network_wrappers.RegistrationModule):
 
         self.regis_net = network
         self.lmbda = lmbda
-
-        assert isinstance(similarity, SimilarityBase)
         self.similarity = similarity
 
     def __call__(self, image_A, image_B) -> ICONLoss:


### PR DESCRIPTION
I don't think we meant to keep this check after switching to the "getattr" approach