### PR TITLE
GradICON requires the itk_wrapper

### DIFF
--- a/src/icon_registration/__init__.py
+++ b/src/icon_registration/__init__.py
@@ -1,16 +1,7 @@
-from icon_registration.losses import (
-    LNCC,
-    LNCCOnlyInterpolated,
-    BlurredSSD,
-    GradientICON,
-    InverseConsistentNet,
-    gaussian_blur,
-    ssd_only_interpolated,
-    ssd,
-    SSDOnlyInterpolated,
-    SSD,
-    NCC
-)
+from icon_registration.losses import (LNCC, LNCCOnlyInterpolated, BlurredSSD,
+                                      GradientICON, InverseConsistentNet,
+                                      gaussian_blur, ssd_only_interpolated,
+                                      ssd, SSDOnlyInterpolated, SSD, NCC)
 from icon_registration.network_wrappers import (
     DownsampleRegistration,
     FunctionFromMatrix,
@@ -19,3 +10,5 @@ from icon_registration.network_wrappers import (
     TwoStepRegistration,
 )
 from icon_registration.train import train_batchfunction, train_datasets
+
+import icon_registration.itk_wrapper


### PR DESCRIPTION
GradICON requires  itk_wrapper. 


File ".../GradICON_Det/determinant_helper.py", line 276, in register_pair_mask
    icon.itk_wrapper.create_itk_transform(phi_AB, model.identity_map, image_A, image_B),
AttributeError: module 'icon_registration' has no attribute ‘itk_wrapper’


